### PR TITLE
Print arguments passed to “bazel run”

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,4 +1,4 @@
-# Copyright 2025 Philipp Stephani
+# Copyright 2025, 2026 Philipp Stephani
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -39,6 +39,7 @@ jobs:
             build --nostamp
             build --experimental_repository_cache_hardlinks
             test --test_output=errors
+            run --noomit_run_args
           disk-cache: true
           repository-cache: true
       - name: Run tests


### PR DESCRIPTION
We never pass anything sensitive on the command line, and printing these arguments on the CI logs helps with debugging.